### PR TITLE
Remove token for codecov

### DIFF
--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage.json
           fail_ci_if_error: true
 


### PR DESCRIPTION
Since it's not needed for public repos.