### PR TITLE
Update to Angular 12.2.11 + types minor versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,27 +9,27 @@
       "version": "5.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@angular-devkit/core": "12.2.10",
-        "@angular-devkit/schematics": "12.2.10",
-        "@angular/cdk": "12.2.10",
-        "@schematics/angular": "12.2.10",
+        "@angular-devkit/core": "12.2.11",
+        "@angular-devkit/schematics": "12.2.11",
+        "@angular/cdk": "12.2.11",
+        "@schematics/angular": "12.2.11",
         "rxjs": "7.4.0",
         "semver": "7.3.5",
         "typescript": "4.4.4"
       },
       "devDependencies": {
-        "@types/jasmine": "3.10.0",
-        "@types/node": "16.11.1",
-        "@types/semver": "7.3.8",
+        "@types/jasmine": "3.10.1",
+        "@types/node": "16.11.5",
+        "@types/semver": "7.3.9",
         "chalk": "4.1.2",
         "istanbul": "0.4.5",
         "jasmine": "3.10.0"
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "12.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.2.10.tgz",
-      "integrity": "sha512-0qhmS7Qvl0hiRVTHxEC/ipFAfzYofPstw0ZITDpEMw+pgHlOZolOlnFrv8LyOXWNqlSIH5fS9D3WF7Hpm7ApYA==",
+      "version": "12.2.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.2.11.tgz",
+      "integrity": "sha512-JgOKDr6zQu/uVZ5le5shgCeIoq3zQvybZGwxjkdWZdoO8rc5oggoiB2PZrPStolhIjFkQ2/mUvhtqnn7D+w8UA==",
       "dependencies": {
         "ajv": "8.6.2",
         "ajv-formats": "2.1.0",
@@ -40,7 +40,7 @@
       },
       "engines": {
         "node": "^12.14.1 || >=14.0.0",
-        "npm": "^6.11.0 || ^7.5.6",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
     },
@@ -61,17 +61,17 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "12.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-12.2.10.tgz",
-      "integrity": "sha512-oQ2EWdkEDE+eAttHeviXsvBi85PsntQT+IffjKUZdbQU+Leuk/pKUpTeea1YosU1p4Cz3PKYF+P/Nl5Jy3B7IQ==",
+      "version": "12.2.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-12.2.11.tgz",
+      "integrity": "sha512-7ucnRGGRGsWqXhvFuK7oAgXMkWO58jmA9CQzXTWCNT5EFCUeyBj2eNNndI4NlWE/LgeKYn7UhUNREzdBrcDiKw==",
       "dependencies": {
-        "@angular-devkit/core": "12.2.10",
+        "@angular-devkit/core": "12.2.11",
         "ora": "5.4.1",
         "rxjs": "6.6.7"
       },
       "engines": {
         "node": "^12.14.1 || >=14.0.0",
-        "npm": "^6.11.0 || ^7.5.6",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
     },
@@ -92,9 +92,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@angular/cdk": {
-      "version": "12.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.2.10.tgz",
-      "integrity": "sha512-jF/tyZXcAS0i11aH8061lMf/ofKs8U52smm/q7k5llTj/NvMZl4s6o3SmdYYE/ByljvCzObz+2j3TzJS/ioDFg==",
+      "version": "12.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.2.11.tgz",
+      "integrity": "sha512-GgBB3NdVSv6RnDDOMspeLGg3uCbbmWIEIQ9VIqT5TWXWnljd2EANOQWdLu+fkmRzJn66FFdlTtJ6rHYoY/oBkA==",
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -140,36 +140,36 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "12.2.10",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-12.2.10.tgz",
-      "integrity": "sha512-hjOWrC/RlZ97oYWO92f5VRu6LDzPHnowDcyGDGvI9wCrfipL4Y7Is6LgFAiVZxCHdRz71MCnES1IXSj5w6UuBA==",
+      "version": "12.2.11",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-12.2.11.tgz",
+      "integrity": "sha512-Xou0CSSD88LVxfl7GzqY3TYUG6mM4cN61zE7gTzqshCx3rR0JkbLn0Z+q67KhxYUs9qiPT5MHL0W06nJ0iLzDg==",
       "dependencies": {
-        "@angular-devkit/core": "12.2.10",
-        "@angular-devkit/schematics": "12.2.10",
+        "@angular-devkit/core": "12.2.11",
+        "@angular-devkit/schematics": "12.2.11",
         "jsonc-parser": "3.0.0"
       },
       "engines": {
         "node": "^12.14.1 || >=14.0.0",
-        "npm": "^6.11.0 || ^7.5.6",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@types/jasmine": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.0.tgz",
-      "integrity": "sha512-sPHWB05cYGt7GXFkkn+03VL1533abxiA5bE8PKdr0nS3cEsOXCGjMk0sgqVwY6xkiwajoAiN3zc/7zDeXip3Pw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.1.tgz",
+      "integrity": "sha512-So26woGjM6F9b2julbJlXdcPdyhwteZzEX2EbFmreuJBamPVVdp6w4djywUG9TmcwjiC+ECAe+RSSBgYEOgEqQ==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.1.tgz",
-      "integrity": "sha512-PYGcJHL9mwl1Ek3PLiYgyEKtwTMmkMw4vbiyz/ps3pfdRYLVv+SN7qHVAImrjdAXxgluDEw6Ph4lyv+m9UpRmA==",
+      "version": "16.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.5.tgz",
+      "integrity": "sha512-NyUV2DGcqYIx9op++MG2+Z4Nhw1tPhi0Wfs81TgncuX1aJC4zf2fgCJlJhl4BW9bCSS04e34VkqmOS96w0XQdg==",
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -1177,9 +1177,9 @@
   },
   "dependencies": {
     "@angular-devkit/core": {
-      "version": "12.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.2.10.tgz",
-      "integrity": "sha512-0qhmS7Qvl0hiRVTHxEC/ipFAfzYofPstw0ZITDpEMw+pgHlOZolOlnFrv8LyOXWNqlSIH5fS9D3WF7Hpm7ApYA==",
+      "version": "12.2.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.2.11.tgz",
+      "integrity": "sha512-JgOKDr6zQu/uVZ5le5shgCeIoq3zQvybZGwxjkdWZdoO8rc5oggoiB2PZrPStolhIjFkQ2/mUvhtqnn7D+w8UA==",
       "requires": {
         "ajv": "8.6.2",
         "ajv-formats": "2.1.0",
@@ -1205,11 +1205,11 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "12.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-12.2.10.tgz",
-      "integrity": "sha512-oQ2EWdkEDE+eAttHeviXsvBi85PsntQT+IffjKUZdbQU+Leuk/pKUpTeea1YosU1p4Cz3PKYF+P/Nl5Jy3B7IQ==",
+      "version": "12.2.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-12.2.11.tgz",
+      "integrity": "sha512-7ucnRGGRGsWqXhvFuK7oAgXMkWO58jmA9CQzXTWCNT5EFCUeyBj2eNNndI4NlWE/LgeKYn7UhUNREzdBrcDiKw==",
       "requires": {
-        "@angular-devkit/core": "12.2.10",
+        "@angular-devkit/core": "12.2.11",
         "ora": "5.4.1",
         "rxjs": "6.6.7"
       },
@@ -1230,9 +1230,9 @@
       }
     },
     "@angular/cdk": {
-      "version": "12.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.2.10.tgz",
-      "integrity": "sha512-jF/tyZXcAS0i11aH8061lMf/ofKs8U52smm/q7k5llTj/NvMZl4s6o3SmdYYE/ByljvCzObz+2j3TzJS/ioDFg==",
+      "version": "12.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.2.11.tgz",
+      "integrity": "sha512-GgBB3NdVSv6RnDDOMspeLGg3uCbbmWIEIQ9VIqT5TWXWnljd2EANOQWdLu+fkmRzJn66FFdlTtJ6rHYoY/oBkA==",
       "requires": {
         "parse5": "^5.0.0",
         "tslib": "^2.2.0"
@@ -1257,31 +1257,31 @@
       }
     },
     "@schematics/angular": {
-      "version": "12.2.10",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-12.2.10.tgz",
-      "integrity": "sha512-hjOWrC/RlZ97oYWO92f5VRu6LDzPHnowDcyGDGvI9wCrfipL4Y7Is6LgFAiVZxCHdRz71MCnES1IXSj5w6UuBA==",
+      "version": "12.2.11",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-12.2.11.tgz",
+      "integrity": "sha512-Xou0CSSD88LVxfl7GzqY3TYUG6mM4cN61zE7gTzqshCx3rR0JkbLn0Z+q67KhxYUs9qiPT5MHL0W06nJ0iLzDg==",
       "requires": {
-        "@angular-devkit/core": "12.2.10",
-        "@angular-devkit/schematics": "12.2.10",
+        "@angular-devkit/core": "12.2.11",
+        "@angular-devkit/schematics": "12.2.11",
         "jsonc-parser": "3.0.0"
       }
     },
     "@types/jasmine": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.0.tgz",
-      "integrity": "sha512-sPHWB05cYGt7GXFkkn+03VL1533abxiA5bE8PKdr0nS3cEsOXCGjMk0sgqVwY6xkiwajoAiN3zc/7zDeXip3Pw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.1.tgz",
+      "integrity": "sha512-So26woGjM6F9b2julbJlXdcPdyhwteZzEX2EbFmreuJBamPVVdp6w4djywUG9TmcwjiC+ECAe+RSSBgYEOgEqQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.1.tgz",
-      "integrity": "sha512-PYGcJHL9mwl1Ek3PLiYgyEKtwTMmkMw4vbiyz/ps3pfdRYLVv+SN7qHVAImrjdAXxgluDEw6Ph4lyv+m9UpRmA==",
+      "version": "16.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.5.tgz",
+      "integrity": "sha512-NyUV2DGcqYIx9op++MG2+Z4Nhw1tPhi0Wfs81TgncuX1aJC4zf2fgCJlJhl4BW9bCSS04e34VkqmOS96w0XQdg==",
       "dev": true
     },
     "@types/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -29,18 +29,18 @@
     "update-deps": "ncu -u --packageFile src/sdk-versions.json"
   },
   "dependencies": {
-    "@angular-devkit/core": "12.2.10",
-    "@angular-devkit/schematics": "12.2.10",
-    "@angular/cdk": "12.2.10",
-    "@schematics/angular": "12.2.10",
+    "@angular-devkit/core": "12.2.11",
+    "@angular-devkit/schematics": "12.2.11",
+    "@angular/cdk": "12.2.11",
+    "@schematics/angular": "12.2.11",
     "rxjs": "7.4.0",
     "semver": "7.3.5",
     "typescript": "4.4.4"
   },
   "devDependencies": {
-    "@types/jasmine": "3.10.0",
-    "@types/node": "16.11.1",
-    "@types/semver": "7.3.8",
+    "@types/jasmine": "3.10.1",
+    "@types/node": "16.11.5",
+    "@types/semver": "7.3.9",
     "chalk": "4.1.2",
     "istanbul": "0.4.5",
     "jasmine": "3.10.0"


### PR DESCRIPTION
```
 @types/jasmine               3.10.0  →   3.10.1
 @types/node                 16.11.1  →  16.11.5
 @types/semver                 7.3.8  →    7.3.9
 @angular-devkit/core        12.2.10  →  12.2.11
 @angular-devkit/schematics  12.2.10  →  12.2.11
 @angular/cdk                12.2.10  →  12.2.11
 @schematics/angular         12.2.10  →  12.2.11
```

Because it's easier than waiting for dependabot.