### PR TITLE
Upgrade Okta and Auth0 SDKs

### DIFF
--- a/src/sdk-versions.json
+++ b/src/sdk-versions.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "description": "Dependencies for npm-check-updates",
   "dependencies": {
-    "@okta/okta-angular": "5.0.0",
-    "@okta/okta-react": "6.3.0",
-    "@okta/okta-auth-js": "5.9.1",
+    "@okta/okta-angular": "5.1.0",
+    "@okta/okta-react": "6.4.1",
+    "@okta/okta-auth-js": "5.10.1",
     "react-router-dom": "5.3.0",
     "@types/react-router-dom": "5.3.2",
     "@okta/okta-react-native": "2.2.0",
@@ -15,7 +15,7 @@
     "enzyme-async-helpers": "0.9.1",
     "react-dom": "17.0.2",
     "@okta/okta-vue2": "3.1.0",
-    "@okta/okta-vue": "5.0.2",
+    "@okta/okta-vue": "5.1.0",
     "ionic-appauth": "0.8.5",
     "@ionic-native/secure-storage": "5.36.0",
     "cordova-plugin-secure-storage-echo": "5.1.1",
@@ -30,7 +30,7 @@
     "@ionic-native/status-bar": "5.36.0",
     "express-session": "1.17.2",
     "@okta/oidc-middleware": "4.3.0",
-    "dotenv": "10.0.0",
-    "@auth0/auth0-angular": "1.8.1"
+    "dotenv": "11.0.0",
+    "@auth0/auth0-angular": "1.8.2"
   }
 }


### PR DESCRIPTION
Minor updates:

```
 @okta/okta-angular     5.0.0  →   5.1.0
 @okta/okta-react       6.3.0  →   6.4.1
 @okta/okta-auth-js     5.9.1  →  5.10.1
 @okta/okta-vue         5.0.2  →   5.1.0
 dotenv                10.0.0  →  11.0.0
 @auth0/auth0-angular   1.8.1  →   1.8.2
```