### PR TITLE
Update Okta SDKs and related dependencies

### DIFF
--- a/src/sdk-versions.json
+++ b/src/sdk-versions.json
@@ -15,7 +15,7 @@
     "enzyme-async-helpers": "0.9.1",
     "react-dom": "17.0.2",
     "@okta/okta-vue2": "3.1.0",
-    "@okta/okta-vue": "5.1.0",
+    "@okta/okta-vue": "5.1.1",
     "ionic-appauth": "0.8.5",
     "@ionic-native/secure-storage": "5.36.0",
     "cordova-plugin-secure-storage-echo": "5.1.1",

--- a/src/sdk-versions.json
+++ b/src/sdk-versions.json
@@ -4,7 +4,7 @@
   "description": "Dependencies for npm-check-updates",
   "dependencies": {
     "@okta/okta-angular": "5.1.1",
-    "@okta/okta-react": "6.4.1",
+    "@okta/okta-react": "6.4.2",
     "@okta/okta-auth-js": "6.0.0",
     "react-router-dom": "5.3.0",
     "@types/react-router-dom": "5.3.3",
@@ -30,7 +30,7 @@
     "@ionic-native/status-bar": "5.36.0",
     "express-session": "1.17.2",
     "@okta/oidc-middleware": "4.5.1",
-    "dotenv": "14.3.2",
+    "dotenv": "15.0.0",
     "@auth0/auth0-angular": "1.8.2"
   }
 }

--- a/src/sdk-versions.json
+++ b/src/sdk-versions.json
@@ -3,12 +3,12 @@
   "version": "0.0.0",
   "description": "Dependencies for npm-check-updates",
   "dependencies": {
-    "@okta/okta-angular": "5.1.0",
+    "@okta/okta-angular": "5.1.1",
     "@okta/okta-react": "6.4.1",
-    "@okta/okta-auth-js": "5.10.1",
+    "@okta/okta-auth-js": "6.0.0",
     "react-router-dom": "5.3.0",
-    "@types/react-router-dom": "5.3.2",
-    "@okta/okta-react-native": "2.2.0",
+    "@types/react-router-dom": "5.3.3",
+    "@okta/okta-react-native": "2.3.0",
     "events": "3.3.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
@@ -25,12 +25,12 @@
     "@ionic-native/http": "5.36.0",
     "@ionic/storage": "3.0.6",
     "@ionic/storage-angular": "3.0.6",
-    "@capacitor/splash-screen": "1.2.0",
+    "@capacitor/splash-screen": "1.2.1",
     "@ionic-native/splash-screen": "5.36.0",
     "@ionic-native/status-bar": "5.36.0",
     "express-session": "1.17.2",
-    "@okta/oidc-middleware": "4.3.0",
-    "dotenv": "11.0.0",
+    "@okta/oidc-middleware": "4.5.1",
+    "dotenv": "14.3.2",
     "@auth0/auth0-angular": "1.8.2"
   }
 }


### PR DESCRIPTION
```
 @okta/okta-angular         5.1.0  →   5.1.1
 @okta/okta-react           6.4.1  →   6.4.2
 @okta/okta-vue             5.1.0  →   5.1.1
 @okta/okta-auth-js        5.10.1  →   6.0.0
 @types/react-router-dom    5.3.2  →   5.3.3
 @okta/okta-react-native    2.2.0  →   2.3.0
 @capacitor/splash-screen   1.2.0  →   1.2.1
 @okta/oidc-middleware      4.3.0  →   4.5.1
 dotenv                    11.0.0  →  15.0.0
```